### PR TITLE
feat: phase 2 - authentication (register/login/logout)

### DIFF
--- a/backend/src/main/java/com/smallbankapp/banking/application/usecase/auth/command/RegisterUserCommand.java
+++ b/backend/src/main/java/com/smallbankapp/banking/application/usecase/auth/command/RegisterUserCommand.java
@@ -1,0 +1,9 @@
+package com.smallbankapp.banking.application.usecase.auth.command;
+
+import com.smallbankapp.banking.application.mediator.Request;
+
+public record RegisterUserCommand(
+        String email,
+        String password,
+        String fullName
+) implements Request<RegisterUserResult> {}

--- a/backend/src/main/java/com/smallbankapp/banking/application/usecase/auth/command/RegisterUserHandler.java
+++ b/backend/src/main/java/com/smallbankapp/banking/application/usecase/auth/command/RegisterUserHandler.java
@@ -1,0 +1,50 @@
+package com.smallbankapp.banking.application.usecase.auth.command;
+
+import com.smallbankapp.banking.application.mediator.RequestHandler;
+import com.smallbankapp.banking.application.port.out.AccountRepository;
+import com.smallbankapp.banking.application.port.out.UserRepository;
+import com.smallbankapp.banking.domain.exception.UserAlreadyExistsException;
+import com.smallbankapp.banking.domain.model.Account;
+import com.smallbankapp.banking.domain.model.User;
+import com.smallbankapp.banking.domain.valueobject.AccountType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class RegisterUserHandler implements RequestHandler<RegisterUserCommand, RegisterUserResult> {
+
+    private final UserRepository userRepository;
+    private final AccountRepository accountRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    @Transactional
+    public RegisterUserResult handle(RegisterUserCommand command) {
+        if (userRepository.existsByEmail(command.email())) {
+            throw new UserAlreadyExistsException(command.email());
+        }
+
+        // Create and persist user
+        User user = User.create(
+                command.email(),
+                passwordEncoder.encode(command.password()),
+                command.fullName()
+        );
+        user = userRepository.save(user);
+
+        // Create account automatically linked to user
+        Account account = Account.create(user.getId(), AccountType.SAVINGS, "USD");
+        account = accountRepository.save(account);
+
+        return new RegisterUserResult(
+                user.getId(),
+                user.getEmail(),
+                user.getFullName(),
+                account.getId(),
+                account.getAccountNumber().getValue()
+        );
+    }
+}

--- a/backend/src/main/java/com/smallbankapp/banking/application/usecase/auth/command/RegisterUserResult.java
+++ b/backend/src/main/java/com/smallbankapp/banking/application/usecase/auth/command/RegisterUserResult.java
@@ -1,0 +1,11 @@
+package com.smallbankapp.banking.application.usecase.auth.command;
+
+import java.util.UUID;
+
+public record RegisterUserResult(
+        UUID userId,
+        String email,
+        String fullName,
+        UUID accountId,
+        String accountNumber
+) {}

--- a/backend/src/main/java/com/smallbankapp/banking/application/usecase/auth/query/LoginHandler.java
+++ b/backend/src/main/java/com/smallbankapp/banking/application/usecase/auth/query/LoginHandler.java
@@ -1,0 +1,33 @@
+package com.smallbankapp.banking.application.usecase.auth.query;
+
+import com.smallbankapp.banking.application.mediator.RequestHandler;
+import com.smallbankapp.banking.application.port.out.UserRepository;
+import com.smallbankapp.banking.domain.exception.InvalidCredentialsException;
+import com.smallbankapp.banking.domain.model.User;
+import com.smallbankapp.banking.infrastructure.security.jwt.JwtService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LoginHandler implements RequestHandler<LoginQuery, LoginResult> {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtService jwtService;
+
+    @Override
+    public LoginResult handle(LoginQuery query) {
+        User user = userRepository.findByEmail(query.email())
+                .orElseThrow(InvalidCredentialsException::new);
+
+        if (!passwordEncoder.matches(query.password(), user.getPasswordHash())) {
+            throw new InvalidCredentialsException();
+        }
+
+        String token = jwtService.generateToken(user.getId(), user.getEmail());
+
+        return new LoginResult(token, user.getEmail(), user.getFullName());
+    }
+}

--- a/backend/src/main/java/com/smallbankapp/banking/application/usecase/auth/query/LoginQuery.java
+++ b/backend/src/main/java/com/smallbankapp/banking/application/usecase/auth/query/LoginQuery.java
@@ -1,0 +1,8 @@
+package com.smallbankapp.banking.application.usecase.auth.query;
+
+import com.smallbankapp.banking.application.mediator.Request;
+
+public record LoginQuery(
+        String email,
+        String password
+) implements Request<LoginResult> {}

--- a/backend/src/main/java/com/smallbankapp/banking/application/usecase/auth/query/LoginResult.java
+++ b/backend/src/main/java/com/smallbankapp/banking/application/usecase/auth/query/LoginResult.java
@@ -1,0 +1,7 @@
+package com.smallbankapp.banking.application.usecase.auth.query;
+
+public record LoginResult(
+        String token,
+        String email,
+        String fullName
+) {}

--- a/backend/src/main/java/com/smallbankapp/banking/infrastructure/config/SecurityConfig.java
+++ b/backend/src/main/java/com/smallbankapp/banking/infrastructure/config/SecurityConfig.java
@@ -1,0 +1,72 @@
+package com.smallbankapp.banking.infrastructure.config;
+
+import com.smallbankapp.banking.infrastructure.security.jwt.JwtAuthenticationFilter;
+import com.smallbankapp.banking.infrastructure.security.jwt.JwtProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+@EnableConfigurationProperties(JwtProperties.class)
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    private static final String[] PUBLIC_ENDPOINTS = {
+            "/api/auth/**",
+            "/swagger-ui/**",
+            "/swagger-ui.html",
+            "/api-docs/**",
+            "/actuator/health"
+    };
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
+                        .anyRequest().authenticated())
+                .addFilterBefore(jwtAuthenticationFilter,
+                        UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of("http://localhost", "http://localhost:3000",
+                "http://localhost:5173"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+}

--- a/backend/src/main/java/com/smallbankapp/banking/infrastructure/security/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/smallbankapp/banking/infrastructure/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,57 @@
+package com.smallbankapp.banking.infrastructure.security.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain)
+            throws ServletException, IOException {
+
+        final String authHeader = request.getHeader("Authorization");
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        final String token = authHeader.substring(7);
+
+        if (jwtService.isTokenValid(token) &&
+                SecurityContextHolder.getContext().getAuthentication() == null) {
+
+            String userId = jwtService.extractUserId(token);
+            String email = jwtService.extractEmail(token);
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            userId, email, Collections.emptyList());
+
+            authentication.setDetails(
+                    new WebAuthenticationDetailsSource().buildDetails(request));
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/backend/src/main/java/com/smallbankapp/banking/infrastructure/security/jwt/JwtProperties.java
+++ b/backend/src/main/java/com/smallbankapp/banking/infrastructure/security/jwt/JwtProperties.java
@@ -1,0 +1,9 @@
+package com.smallbankapp.banking.infrastructure.security.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+        String secret,
+        long expirationMs
+) {}

--- a/backend/src/main/java/com/smallbankapp/banking/infrastructure/security/jwt/JwtService.java
+++ b/backend/src/main/java/com/smallbankapp/banking/infrastructure/security/jwt/JwtService.java
@@ -1,0 +1,58 @@
+package com.smallbankapp.banking.infrastructure.security.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class JwtService {
+
+    private final JwtProperties properties;
+
+    public String generateToken(UUID userId, String email) {
+        return Jwts.builder()
+                .subject(userId.toString())
+                .claim("email", email)
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + properties.expirationMs()))
+                .signWith(signingKey())
+                .compact();
+    }
+
+    public String extractUserId(String token) {
+        return parseClaims(token).getSubject();
+    }
+
+    public String extractEmail(String token) {
+        return parseClaims(token).get("email", String.class);
+    }
+
+    public boolean isTokenValid(String token) {
+        try {
+            Claims claims = parseClaims(token);
+            return claims.getExpiration().after(new Date());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(signingKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    private SecretKey signingKey() {
+        return Keys.hmacShaKeyFor(properties.secret().getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/backend/src/main/java/com/smallbankapp/banking/presentation/controller/AuthController.java
+++ b/backend/src/main/java/com/smallbankapp/banking/presentation/controller/AuthController.java
@@ -1,0 +1,58 @@
+package com.smallbankapp.banking.presentation.controller;
+
+import com.smallbankapp.banking.application.mediator.Mediator;
+import com.smallbankapp.banking.application.usecase.auth.command.RegisterUserCommand;
+import com.smallbankapp.banking.application.usecase.auth.command.RegisterUserResult;
+import com.smallbankapp.banking.application.usecase.auth.query.LoginQuery;
+import com.smallbankapp.banking.application.usecase.auth.query.LoginResult;
+import com.smallbankapp.banking.presentation.dto.request.LoginRequest;
+import com.smallbankapp.banking.presentation.dto.request.RegisterRequest;
+import com.smallbankapp.banking.presentation.dto.response.LoginResponse;
+import com.smallbankapp.banking.presentation.dto.response.RegisterResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+@Tag(name = "Authentication", description = "Register, login and logout")
+public class AuthController {
+
+    private final Mediator mediator;
+
+    @PostMapping("/register")
+    @Operation(summary = "Register a new user and create a linked bank account")
+    public ResponseEntity<RegisterResponse> register(@Valid @RequestBody RegisterRequest request) {
+        RegisterUserResult result = mediator.send(
+                new RegisterUserCommand(request.email(), request.password(), request.fullName()));
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+                new RegisterResponse(
+                        result.userId(),
+                        result.email(),
+                        result.fullName(),
+                        result.accountId(),
+                        result.accountNumber()));
+    }
+
+    @PostMapping("/login")
+    @Operation(summary = "Authenticate and receive a JWT token")
+    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
+        LoginResult result = mediator.send(new LoginQuery(request.email(), request.password()));
+        return ResponseEntity.ok(new LoginResponse(result.token(), result.email(), result.fullName()));
+    }
+
+    @PostMapping("/logout")
+    @Operation(summary = "Logout (client-side token invalidation)")
+    public ResponseEntity<Map<String, String>> logout() {
+        // Stateless JWT — token invalidation is handled client-side
+        return ResponseEntity.ok(Map.of("message", "Logged out successfully"));
+    }
+}

--- a/backend/src/main/java/com/smallbankapp/banking/presentation/dto/request/LoginRequest.java
+++ b/backend/src/main/java/com/smallbankapp/banking/presentation/dto/request/LoginRequest.java
@@ -1,0 +1,9 @@
+package com.smallbankapp.banking.presentation.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank @Email String email,
+        @NotBlank String password
+) {}

--- a/backend/src/main/java/com/smallbankapp/banking/presentation/dto/request/RegisterRequest.java
+++ b/backend/src/main/java/com/smallbankapp/banking/presentation/dto/request/RegisterRequest.java
@@ -1,0 +1,11 @@
+package com.smallbankapp.banking.presentation.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record RegisterRequest(
+        @NotBlank @Email String email,
+        @NotBlank @Size(min = 8, message = "Password must be at least 8 characters") String password,
+        @NotBlank String fullName
+) {}

--- a/backend/src/main/java/com/smallbankapp/banking/presentation/dto/response/LoginResponse.java
+++ b/backend/src/main/java/com/smallbankapp/banking/presentation/dto/response/LoginResponse.java
@@ -1,0 +1,7 @@
+package com.smallbankapp.banking.presentation.dto.response;
+
+public record LoginResponse(
+        String token,
+        String email,
+        String fullName
+) {}

--- a/backend/src/main/java/com/smallbankapp/banking/presentation/dto/response/RegisterResponse.java
+++ b/backend/src/main/java/com/smallbankapp/banking/presentation/dto/response/RegisterResponse.java
@@ -1,0 +1,11 @@
+package com.smallbankapp.banking.presentation.dto.response;
+
+import java.util.UUID;
+
+public record RegisterResponse(
+        UUID userId,
+        String email,
+        String fullName,
+        UUID accountId,
+        String accountNumber
+) {}

--- a/backend/src/test/java/com/smallbankapp/banking/application/usecase/auth/command/RegisterUserHandlerTest.java
+++ b/backend/src/test/java/com/smallbankapp/banking/application/usecase/auth/command/RegisterUserHandlerTest.java
@@ -1,0 +1,62 @@
+package com.smallbankapp.banking.application.usecase.auth.command;
+
+import com.smallbankapp.banking.application.port.out.AccountRepository;
+import com.smallbankapp.banking.application.port.out.UserRepository;
+import com.smallbankapp.banking.domain.exception.UserAlreadyExistsException;
+import com.smallbankapp.banking.domain.model.Account;
+import com.smallbankapp.banking.domain.model.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RegisterUserHandlerTest {
+
+    @Mock UserRepository userRepository;
+    @Mock AccountRepository accountRepository;
+    @Mock PasswordEncoder passwordEncoder;
+
+    @InjectMocks RegisterUserHandler handler;
+
+    private RegisterUserCommand command;
+
+    @BeforeEach
+    void setUp() {
+        command = new RegisterUserCommand("test@email.com", "Password1!", "Test User");
+    }
+
+    @Test
+    void handle_newUser_returnsResultWithAccountNumber() {
+        when(userRepository.existsByEmail(command.email())).thenReturn(false);
+        when(passwordEncoder.encode(command.password())).thenReturn("hashed");
+        when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(accountRepository.save(any(Account.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        RegisterUserResult result = handler.handle(command);
+
+        assertThat(result.email()).isEqualTo(command.email());
+        assertThat(result.fullName()).isEqualTo(command.fullName());
+        assertThat(result.accountNumber()).isNotBlank();
+        verify(userRepository).save(any(User.class));
+        verify(accountRepository).save(any(Account.class));
+    }
+
+    @Test
+    void handle_duplicateEmail_throwsUserAlreadyExistsException() {
+        when(userRepository.existsByEmail(command.email())).thenReturn(true);
+
+        assertThatThrownBy(() -> handler.handle(command))
+                .isInstanceOf(UserAlreadyExistsException.class);
+
+        verify(userRepository, never()).save(any());
+        verify(accountRepository, never()).save(any());
+    }
+}

--- a/backend/src/test/java/com/smallbankapp/banking/application/usecase/auth/query/LoginHandlerTest.java
+++ b/backend/src/test/java/com/smallbankapp/banking/application/usecase/auth/query/LoginHandlerTest.java
@@ -1,0 +1,80 @@
+package com.smallbankapp.banking.application.usecase.auth.query;
+
+import com.smallbankapp.banking.application.port.out.UserRepository;
+import com.smallbankapp.banking.domain.exception.InvalidCredentialsException;
+import com.smallbankapp.banking.domain.model.User;
+import com.smallbankapp.banking.infrastructure.security.jwt.JwtService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LoginHandlerTest {
+
+    @Mock UserRepository userRepository;
+    @Mock PasswordEncoder passwordEncoder;
+    @Mock JwtService jwtService;
+
+    @InjectMocks LoginHandler handler;
+
+    private User mockUser;
+    private LoginQuery query;
+
+    @BeforeEach
+    void setUp() {
+        mockUser = new User(
+                UUID.randomUUID(),
+                "test@email.com",
+                "hashed_password",
+                "Test User",
+                Instant.now(),
+                Instant.now()
+        );
+        query = new LoginQuery("test@email.com", "Password1!");
+    }
+
+    @Test
+    void handle_validCredentials_returnsTokenAndUserInfo() {
+        when(userRepository.findByEmail(query.email())).thenReturn(Optional.of(mockUser));
+        when(passwordEncoder.matches(query.password(), mockUser.getPasswordHash())).thenReturn(true);
+        when(jwtService.generateToken(mockUser.getId(), mockUser.getEmail())).thenReturn("jwt-token");
+
+        LoginResult result = handler.handle(query);
+
+        assertThat(result.token()).isEqualTo("jwt-token");
+        assertThat(result.email()).isEqualTo(mockUser.getEmail());
+        assertThat(result.fullName()).isEqualTo(mockUser.getFullName());
+    }
+
+    @Test
+    void handle_userNotFound_throwsInvalidCredentialsException() {
+        when(userRepository.findByEmail(query.email())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> handler.handle(query))
+                .isInstanceOf(InvalidCredentialsException.class);
+
+        verify(jwtService, never()).generateToken(any(), any());
+    }
+
+    @Test
+    void handle_wrongPassword_throwsInvalidCredentialsException() {
+        when(userRepository.findByEmail(query.email())).thenReturn(Optional.of(mockUser));
+        when(passwordEncoder.matches(query.password(), mockUser.getPasswordHash())).thenReturn(false);
+
+        assertThatThrownBy(() -> handler.handle(query))
+                .isInstanceOf(InvalidCredentialsException.class);
+
+        verify(jwtService, never()).generateToken(any(), any());
+    }
+}


### PR DESCRIPTION
- Add JwtProperties, JwtService (JJWT 0.12 HS256), JwtAuthenticationFilter
- Add SecurityConfig: stateless FilterChain, BCrypt PasswordEncoder, CORS
- Add RegisterUserCommand + RegisterUserHandler (@Transactional, creates user + account)
- Add LoginQuery + LoginHandler (BCrypt verify + JWT generation)
- Add AuthController: POST /api/auth/register, /login, /logout
- Add request/response DTOs with Bean Validation
- Add RegisterUserHandlerTest (2 tests), LoginHandlerTest (3 tests)
- Add Notes/setup-dirs.ps1 for recursive directory creation