### PR TITLE
feat: phase 3 - account management

### DIFF
--- a/backend/src/main/java/com/smallbankapp/banking/application/usecase/account/query/GetAccountHandler.java
+++ b/backend/src/main/java/com/smallbankapp/banking/application/usecase/account/query/GetAccountHandler.java
@@ -1,0 +1,32 @@
+package com.smallbankapp.banking.application.usecase.account.query;
+
+import com.smallbankapp.banking.application.mediator.RequestHandler;
+import com.smallbankapp.banking.application.port.out.AccountRepository;
+import com.smallbankapp.banking.domain.exception.AccountNotFoundException;
+import com.smallbankapp.banking.domain.model.Account;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GetAccountHandler implements RequestHandler<GetAccountQuery, GetAccountResult> {
+
+    private final AccountRepository accountRepository;
+
+    @Override
+    public GetAccountResult handle(GetAccountQuery query) {
+        Account account = accountRepository.findById(query.accountId())
+                .orElseThrow(() -> new AccountNotFoundException(query.accountId().toString()));
+
+        return new GetAccountResult(
+                account.getId(),
+                account.getUserId(),
+                account.getAccountNumber().getValue(),
+                account.getAccountType().name(),
+                account.getBalance().getAmount(),
+                account.getBalance().getCurrency(),
+                account.getStatus().name(),
+                account.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/smallbankapp/banking/application/usecase/account/query/GetAccountQuery.java
+++ b/backend/src/main/java/com/smallbankapp/banking/application/usecase/account/query/GetAccountQuery.java
@@ -1,0 +1,7 @@
+package com.smallbankapp.banking.application.usecase.account.query;
+
+import com.smallbankapp.banking.application.mediator.Request;
+
+import java.util.UUID;
+
+public record GetAccountQuery(UUID accountId) implements Request<GetAccountResult> {}

--- a/backend/src/main/java/com/smallbankapp/banking/application/usecase/account/query/GetAccountResult.java
+++ b/backend/src/main/java/com/smallbankapp/banking/application/usecase/account/query/GetAccountResult.java
@@ -1,0 +1,16 @@
+package com.smallbankapp.banking.application.usecase.account.query;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+public record GetAccountResult(
+        UUID accountId,
+        UUID userId,
+        String accountNumber,
+        String accountType,
+        BigDecimal balance,
+        String currency,
+        String status,
+        Instant createdAt
+) {}

--- a/backend/src/main/java/com/smallbankapp/banking/application/usecase/account/query/GetBalanceHandler.java
+++ b/backend/src/main/java/com/smallbankapp/banking/application/usecase/account/query/GetBalanceHandler.java
@@ -1,0 +1,28 @@
+package com.smallbankapp.banking.application.usecase.account.query;
+
+import com.smallbankapp.banking.application.mediator.RequestHandler;
+import com.smallbankapp.banking.application.port.out.AccountRepository;
+import com.smallbankapp.banking.domain.exception.AccountNotFoundException;
+import com.smallbankapp.banking.domain.model.Account;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GetBalanceHandler implements RequestHandler<GetBalanceQuery, GetBalanceResult> {
+
+    private final AccountRepository accountRepository;
+
+    @Override
+    public GetBalanceResult handle(GetBalanceQuery query) {
+        Account account = accountRepository.findById(query.accountId())
+                .orElseThrow(() -> new AccountNotFoundException(query.accountId().toString()));
+
+        return new GetBalanceResult(
+                account.getId(),
+                account.getAccountNumber().getValue(),
+                account.getBalance().getAmount(),
+                account.getBalance().getCurrency()
+        );
+    }
+}

--- a/backend/src/main/java/com/smallbankapp/banking/application/usecase/account/query/GetBalanceQuery.java
+++ b/backend/src/main/java/com/smallbankapp/banking/application/usecase/account/query/GetBalanceQuery.java
@@ -1,0 +1,7 @@
+package com.smallbankapp.banking.application.usecase.account.query;
+
+import com.smallbankapp.banking.application.mediator.Request;
+
+import java.util.UUID;
+
+public record GetBalanceQuery(UUID accountId) implements Request<GetBalanceResult> {}

--- a/backend/src/main/java/com/smallbankapp/banking/application/usecase/account/query/GetBalanceResult.java
+++ b/backend/src/main/java/com/smallbankapp/banking/application/usecase/account/query/GetBalanceResult.java
@@ -1,0 +1,11 @@
+package com.smallbankapp.banking.application.usecase.account.query;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record GetBalanceResult(
+        UUID accountId,
+        String accountNumber,
+        BigDecimal balance,
+        String currency
+) {}

--- a/backend/src/main/java/com/smallbankapp/banking/infrastructure/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/smallbankapp/banking/infrastructure/config/OpenApiConfig.java
@@ -1,0 +1,26 @@
+package com.smallbankapp.banking.infrastructure.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Small Banking App API")
+                        .description("Online Banking System — Technical Interview")
+                        .version("1.0.0"))
+                .components(new Components()
+                        .addSecuritySchemes("bearerAuth", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
+    }
+}

--- a/backend/src/main/java/com/smallbankapp/banking/presentation/controller/AccountController.java
+++ b/backend/src/main/java/com/smallbankapp/banking/presentation/controller/AccountController.java
@@ -1,0 +1,55 @@
+package com.smallbankapp.banking.presentation.controller;
+
+import com.smallbankapp.banking.application.mediator.Mediator;
+import com.smallbankapp.banking.application.usecase.account.query.GetAccountQuery;
+import com.smallbankapp.banking.application.usecase.account.query.GetAccountResult;
+import com.smallbankapp.banking.application.usecase.account.query.GetBalanceQuery;
+import com.smallbankapp.banking.application.usecase.account.query.GetBalanceResult;
+import com.smallbankapp.banking.presentation.dto.response.AccountResponse;
+import com.smallbankapp.banking.presentation.dto.response.BalanceResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/accounts")
+@RequiredArgsConstructor
+@Tag(name = "Accounts", description = "Account information and balance")
+@SecurityRequirement(name = "bearerAuth")
+public class AccountController {
+
+    private final Mediator mediator;
+
+    @GetMapping("/{accountId}")
+    @Operation(summary = "Get account details by ID")
+    public ResponseEntity<AccountResponse> getAccount(@PathVariable UUID accountId) {
+        GetAccountResult result = mediator.send(new GetAccountQuery(accountId));
+        return ResponseEntity.ok(new AccountResponse(
+                result.accountId(),
+                result.userId(),
+                result.accountNumber(),
+                result.accountType(),
+                result.balance(),
+                result.currency(),
+                result.status(),
+                result.createdAt()
+        ));
+    }
+
+    @GetMapping("/{accountId}/balance")
+    @Operation(summary = "Get current balance for an account")
+    public ResponseEntity<BalanceResponse> getBalance(@PathVariable UUID accountId) {
+        GetBalanceResult result = mediator.send(new GetBalanceQuery(accountId));
+        return ResponseEntity.ok(new BalanceResponse(
+                result.accountId(),
+                result.accountNumber(),
+                result.balance(),
+                result.currency()
+        ));
+    }
+}

--- a/backend/src/main/java/com/smallbankapp/banking/presentation/dto/response/AccountResponse.java
+++ b/backend/src/main/java/com/smallbankapp/banking/presentation/dto/response/AccountResponse.java
@@ -1,0 +1,16 @@
+package com.smallbankapp.banking.presentation.dto.response;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+public record AccountResponse(
+        UUID accountId,
+        UUID userId,
+        String accountNumber,
+        String accountType,
+        BigDecimal balance,
+        String currency,
+        String status,
+        Instant createdAt
+) {}

--- a/backend/src/main/java/com/smallbankapp/banking/presentation/dto/response/BalanceResponse.java
+++ b/backend/src/main/java/com/smallbankapp/banking/presentation/dto/response/BalanceResponse.java
@@ -1,0 +1,11 @@
+package com.smallbankapp.banking.presentation.dto.response;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record BalanceResponse(
+        UUID accountId,
+        String accountNumber,
+        BigDecimal balance,
+        String currency
+) {}

--- a/backend/src/test/java/com/smallbankapp/banking/application/usecase/account/query/GetAccountHandlerTest.java
+++ b/backend/src/test/java/com/smallbankapp/banking/application/usecase/account/query/GetAccountHandlerTest.java
@@ -1,0 +1,67 @@
+package com.smallbankapp.banking.application.usecase.account.query;
+
+import com.smallbankapp.banking.application.port.out.AccountRepository;
+import com.smallbankapp.banking.domain.exception.AccountNotFoundException;
+import com.smallbankapp.banking.domain.model.Account;
+import com.smallbankapp.banking.domain.valueobject.AccountNumber;
+import com.smallbankapp.banking.domain.valueobject.AccountStatus;
+import com.smallbankapp.banking.domain.valueobject.AccountType;
+import com.smallbankapp.banking.domain.valueobject.Money;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GetAccountHandlerTest {
+
+    @Mock AccountRepository accountRepository;
+    @InjectMocks GetAccountHandler handler;
+
+    private Account mockAccount;
+    private UUID accountId;
+
+    @BeforeEach
+    void setUp() {
+        accountId = UUID.randomUUID();
+        mockAccount = new Account(
+                accountId,
+                UUID.randomUUID(),
+                AccountNumber.of("1234567890"),
+                AccountType.SAVINGS,
+                Money.of(500.0, "USD"),
+                AccountStatus.ACTIVE,
+                Instant.now(),
+                Instant.now()
+        );
+    }
+
+    @Test
+    void handle_existingAccount_returnsAccountResult() {
+        when(accountRepository.findById(accountId)).thenReturn(Optional.of(mockAccount));
+
+        GetAccountResult result = handler.handle(new GetAccountQuery(accountId));
+
+        assertThat(result.accountId()).isEqualTo(accountId);
+        assertThat(result.accountNumber()).isEqualTo("1234567890");
+        assertThat(result.accountType()).isEqualTo("SAVINGS");
+        assertThat(result.status()).isEqualTo("ACTIVE");
+    }
+
+    @Test
+    void handle_nonExistingAccount_throwsAccountNotFoundException() {
+        when(accountRepository.findById(accountId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> handler.handle(new GetAccountQuery(accountId)))
+                .isInstanceOf(AccountNotFoundException.class);
+    }
+}

--- a/backend/src/test/java/com/smallbankapp/banking/application/usecase/account/query/GetBalanceHandlerTest.java
+++ b/backend/src/test/java/com/smallbankapp/banking/application/usecase/account/query/GetBalanceHandlerTest.java
@@ -1,0 +1,67 @@
+package com.smallbankapp.banking.application.usecase.account.query;
+
+import com.smallbankapp.banking.application.port.out.AccountRepository;
+import com.smallbankapp.banking.domain.exception.AccountNotFoundException;
+import com.smallbankapp.banking.domain.model.Account;
+import com.smallbankapp.banking.domain.valueobject.AccountNumber;
+import com.smallbankapp.banking.domain.valueobject.AccountStatus;
+import com.smallbankapp.banking.domain.valueobject.AccountType;
+import com.smallbankapp.banking.domain.valueobject.Money;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GetBalanceHandlerTest {
+
+    @Mock AccountRepository accountRepository;
+    @InjectMocks GetBalanceHandler handler;
+
+    private Account mockAccount;
+    private UUID accountId;
+
+    @BeforeEach
+    void setUp() {
+        accountId = UUID.randomUUID();
+        mockAccount = new Account(
+                accountId,
+                UUID.randomUUID(),
+                AccountNumber.of("1234567890"),
+                AccountType.SAVINGS,
+                Money.of(1250.50, "USD"),
+                AccountStatus.ACTIVE,
+                Instant.now(),
+                Instant.now()
+        );
+    }
+
+    @Test
+    void handle_existingAccount_returnsBalance() {
+        when(accountRepository.findById(accountId)).thenReturn(Optional.of(mockAccount));
+
+        GetBalanceResult result = handler.handle(new GetBalanceQuery(accountId));
+
+        assertThat(result.accountId()).isEqualTo(accountId);
+        assertThat(result.accountNumber()).isEqualTo("1234567890");
+        assertThat(result.currency()).isEqualTo("USD");
+        assertThat(result.balance()).isPositive();
+    }
+
+    @Test
+    void handle_nonExistingAccount_throwsAccountNotFoundException() {
+        when(accountRepository.findById(accountId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> handler.handle(new GetBalanceQuery(accountId)))
+                .isInstanceOf(AccountNotFoundException.class);
+    }
+}


### PR DESCRIPTION
- Add GetAccountQuery + GetAccountHandler
- Add GetBalanceQuery + GetBalanceHandler
- Add AccountResponse, BalanceResponse DTOs
- Add AccountController: GET /api/accounts/{id}, /api/accounts/{id}/balance
- Add OpenApiConfig with bearerAuth security scheme
- Add GetAccountHandlerTest (2 tests), GetBalanceHandlerTest (2 tests)

Note: CreateAccountCommand omitted — account creation is handled atomically inside RegisterUserHandler (Phase 2)