### PR TITLE
feat(phase-5): implement Kafka messaging layer

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -14,7 +14,7 @@
     <groupId>com.smallbankapp</groupId>
     <artifactId>banking</artifactId>
     <version>0.0.1-SNAPSHOT</version>
-    <name>banking</name>
+    <n>banking</n>
     <description>Online Banking System — Technical Interview</description>
 
     <properties>
@@ -153,6 +153,13 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>kafka</artifactId>
             <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- ===== Awaitility (integration tests) ===== -->
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.2.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/backend/src/main/java/com/smallbankapp/banking/infrastructure/config/KafkaConfig.java
+++ b/backend/src/main/java/com/smallbankapp/banking/infrastructure/config/KafkaConfig.java
@@ -1,0 +1,95 @@
+package com.smallbankapp.banking.infrastructure.config;
+
+import com.smallbankapp.banking.infrastructure.messaging.kafka.event.TransactionEvent;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.*;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Kafka infrastructure configuration.
+ * Topics, producer/consumer factories, and listener container factory.
+ * Dead-letter topic (DLT) is handled automatically by @RetryableTopic on the consumer.
+ */
+@Configuration
+public class KafkaConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    // ── Topics ───────────────────────────────────────────────────────────────
+
+    @Bean
+    public NewTopic transactionsTopic() {
+        return TopicBuilder.name("banking.transactions")
+                .partitions(3)
+                .replicas(1)
+                .build();
+    }
+
+    @Bean
+    public NewTopic transactionsDltTopic() {
+        return TopicBuilder.name("banking.transactions.DLT")
+                .partitions(1)
+                .replicas(1)
+                .build();
+    }
+
+    // ── Producer ─────────────────────────────────────────────────────────────
+
+    @Bean
+    public ProducerFactory<String, TransactionEvent> producerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        props.put(ProducerConfig.ACKS_CONFIG, "all");
+        props.put(ProducerConfig.RETRIES_CONFIG, 3);
+        props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+    @Bean
+    public KafkaTemplate<String, TransactionEvent> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    // ── Consumer ─────────────────────────────────────────────────────────────
+
+    @Bean
+    public ConsumerFactory<String, TransactionEvent> consumerFactory() {
+        JsonDeserializer<TransactionEvent> deserializer =
+                new JsonDeserializer<>(TransactionEvent.class, false);
+        deserializer.addTrustedPackages("com.smallbankapp.banking.*");
+
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "banking-group");
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+        return new DefaultKafkaConsumerFactory<>(props, new StringDeserializer(), deserializer);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, TransactionEvent> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, TransactionEvent> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        factory.setConcurrency(2);
+        return factory;
+    }
+}

--- a/backend/src/main/java/com/smallbankapp/banking/infrastructure/messaging/kafka/consumer/AuditLogConsumer.java
+++ b/backend/src/main/java/com/smallbankapp/banking/infrastructure/messaging/kafka/consumer/AuditLogConsumer.java
@@ -1,0 +1,72 @@
+package com.smallbankapp.banking.infrastructure.messaging.kafka.consumer;
+
+import com.smallbankapp.banking.infrastructure.messaging.kafka.event.TransactionEvent;
+import com.smallbankapp.banking.infrastructure.persistence.mongo.document.AuditLogDocument;
+import com.smallbankapp.banking.infrastructure.persistence.mongo.repository.AuditLogMongoRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.kafka.retrytopic.TopicSuffixingStrategy;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+
+/**
+ * Consumes TransactionEvents from "banking.transactions" and persists
+ * an immutable audit log entry to MongoDB.
+ *
+ * Retry strategy: 3 attempts with exponential backoff, then DLT.
+ * Idempotent: skips if the transactionId already exists in audit_logs.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuditLogConsumer {
+
+    private final AuditLogMongoRepository auditLogMongoRepository;
+
+    @RetryableTopic(
+            attempts = "3",
+            backoff = @Backoff(delay = 1000, multiplier = 2.0),
+            topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE,
+            dltTopicSuffix = ".DLT",
+            autoCreateTopics = "true"
+    )
+    @KafkaListener(
+            topics = "banking.transactions",
+            groupId = "audit-log-group",
+            containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void consume(TransactionEvent event) {
+        log.debug("AuditLogConsumer received event [transactionId={}]", event.transactionId());
+
+        // Idempotency guard
+        if (auditLogMongoRepository.existsByTransactionId(event.transactionId())) {
+            log.info("Duplicate audit event skipped [transactionId={}]", event.transactionId());
+            return;
+        }
+
+        AuditLogDocument auditLog = AuditLogDocument.builder()
+                .transactionId(event.transactionId())
+                .accountId(event.sourceAccountId() != null ? event.sourceAccountId() : event.targetAccountId())
+                .eventType(event.type())
+                .amount(event.amount())
+                .currency(event.currency())
+                .status(event.status())
+                .metadata(buildMetadata(event))
+                .timestamp(Instant.now())
+                .build();
+
+        auditLogMongoRepository.save(auditLog);
+        log.info("Audit log persisted [transactionId={}, type={}]", event.transactionId(), event.type());
+    }
+
+    private String buildMetadata(TransactionEvent event) {
+        if (event.sourceAccountId() != null && event.targetAccountId() != null) {
+            return String.format("transfer: %s -> %s", event.sourceAccountId(), event.targetAccountId());
+        }
+        return event.type().toLowerCase();
+    }
+}

--- a/backend/src/main/java/com/smallbankapp/banking/infrastructure/messaging/kafka/consumer/TransactionHistoryConsumer.java
+++ b/backend/src/main/java/com/smallbankapp/banking/infrastructure/messaging/kafka/consumer/TransactionHistoryConsumer.java
@@ -1,0 +1,74 @@
+package com.smallbankapp.banking.infrastructure.messaging.kafka.consumer;
+
+import com.smallbankapp.banking.infrastructure.messaging.kafka.event.TransactionEvent;
+import com.smallbankapp.banking.infrastructure.persistence.mongo.document.TransactionHistoryDocument;
+import com.smallbankapp.banking.infrastructure.persistence.mongo.repository.TransactionHistoryMongoRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.kafka.retrytopic.TopicSuffixingStrategy;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+/**
+ * Consumes TransactionEvents and persists a denormalized history record
+ * to MongoDB (transaction_history collection) for fast read-side queries.
+ *
+ * Idempotent: skips duplicate transactionIds.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TransactionHistoryConsumer {
+
+    private final TransactionHistoryMongoRepository transactionHistoryMongoRepository;
+
+    @RetryableTopic(
+            attempts = "3",
+            backoff = @Backoff(delay = 1000, multiplier = 2.0),
+            topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE,
+            dltTopicSuffix = ".DLT",
+            autoCreateTopics = "true"
+    )
+    @KafkaListener(
+            topics = "banking.transactions",
+            groupId = "transaction-history-group",
+            containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void consume(TransactionEvent event) {
+        log.debug("TransactionHistoryConsumer received event [transactionId={}]", event.transactionId());
+
+        // Idempotency guard
+        if (transactionHistoryMongoRepository.existsByTransactionId(event.transactionId())) {
+            log.info("Duplicate history event skipped [transactionId={}]", event.transactionId());
+            return;
+        }
+
+        UUID primaryAccountId = event.sourceAccountId() != null
+                ? event.sourceAccountId()
+                : event.targetAccountId();
+
+        UUID counterpart = (event.sourceAccountId() != null && event.targetAccountId() != null)
+                ? event.targetAccountId()
+                : null;
+
+        TransactionHistoryDocument doc = TransactionHistoryDocument.builder()
+                .transactionId(event.transactionId())
+                .accountId(primaryAccountId)
+                .counterpartAccountId(counterpart)
+                .transactionType(event.type())
+                .amount(event.amount())
+                .currency(event.currency())
+                .description(null) // description lives in SQL only
+                .status(event.status())
+                .createdAt(event.timestamp())
+                .build();
+
+        transactionHistoryMongoRepository.save(doc);
+        log.info("Transaction history persisted [transactionId={}, type={}]",
+                event.transactionId(), event.type());
+    }
+}

--- a/backend/src/main/java/com/smallbankapp/banking/infrastructure/messaging/kafka/event/TransactionEvent.java
+++ b/backend/src/main/java/com/smallbankapp/banking/infrastructure/messaging/kafka/event/TransactionEvent.java
@@ -1,0 +1,36 @@
+package com.smallbankapp.banking.infrastructure.messaging.kafka.event;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Kafka event payload for every completed transaction.
+ * Published to topic: banking.transactions
+ * Dead-letter topic:  banking.transactions.DLT
+ */
+public record TransactionEvent(
+        UUID transactionId,
+        UUID sourceAccountId,
+        UUID targetAccountId,
+        String type,
+        BigDecimal amount,
+        String currency,
+        String status,
+        Instant timestamp
+) {
+    /** Convenience factory from infrastructure-layer data. */
+    public static TransactionEvent of(
+            UUID transactionId,
+            UUID sourceAccountId,
+            UUID targetAccountId,
+            String type,
+            BigDecimal amount,
+            String currency,
+            String status,
+            Instant timestamp) {
+        return new TransactionEvent(
+                transactionId, sourceAccountId, targetAccountId,
+                type, amount, currency, status, timestamp);
+    }
+}

--- a/backend/src/main/java/com/smallbankapp/banking/infrastructure/messaging/kafka/producer/KafkaTransactionProducer.java
+++ b/backend/src/main/java/com/smallbankapp/banking/infrastructure/messaging/kafka/producer/KafkaTransactionProducer.java
@@ -1,0 +1,65 @@
+package com.smallbankapp.banking.infrastructure.messaging.kafka.producer;
+
+import com.smallbankapp.banking.application.port.out.TransactionEventPublisher;
+import com.smallbankapp.banking.domain.model.Transaction;
+import com.smallbankapp.banking.infrastructure.messaging.kafka.event.TransactionEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Kafka adapter that implements the TransactionEventPublisher domain port.
+ * Publishes TransactionEvent to the "banking.transactions" topic.
+ * Spring Kafka auto-configures the dead-letter topic on deserialization failure.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaTransactionProducer implements TransactionEventPublisher {
+
+    static final String TOPIC = "banking.transactions";
+
+    private final KafkaTemplate<String, TransactionEvent> kafkaTemplate;
+
+    @Override
+    public void publish(Transaction transaction) {
+        TransactionEvent event = TransactionEvent.of(
+                transaction.getId(),
+                transaction.getSourceAccountId(),
+                transaction.getTargetAccountId(),
+                transaction.getType().name(),
+                transaction.getAmount().getAmount(),
+                transaction.getAmount().getCurrency(),
+                transaction.getStatus().name(),
+                transaction.getCreatedAt()
+        );
+
+        // Partition key: accountId (source or target) for ordering per account
+        String key = resolveKey(transaction);
+
+        CompletableFuture<SendResult<String, TransactionEvent>> future =
+                kafkaTemplate.send(TOPIC, key, event);
+
+        future.whenComplete((result, ex) -> {
+            if (ex != null) {
+                log.error("Failed to publish TransactionEvent [id={}]: {}",
+                        transaction.getId(), ex.getMessage(), ex);
+            } else {
+                log.debug("TransactionEvent published [id={}, partition={}, offset={}]",
+                        transaction.getId(),
+                        result.getRecordMetadata().partition(),
+                        result.getRecordMetadata().offset());
+            }
+        });
+    }
+
+    private String resolveKey(Transaction t) {
+        if (t.getSourceAccountId() != null) return t.getSourceAccountId().toString();
+        if (t.getTargetAccountId() != null) return t.getTargetAccountId().toString();
+        return t.getId().toString();
+    }
+}

--- a/backend/src/main/java/com/smallbankapp/banking/infrastructure/persistence/mongo/repository/TransactionHistoryMongoRepository.java
+++ b/backend/src/main/java/com/smallbankapp/banking/infrastructure/persistence/mongo/repository/TransactionHistoryMongoRepository.java
@@ -9,4 +9,5 @@ import java.util.UUID;
 
 public interface TransactionHistoryMongoRepository extends MongoRepository<TransactionHistoryDocument, String> {
     Page<TransactionHistoryDocument> findByAccountIdOrderByCreatedAtDesc(UUID accountId, Pageable pageable);
+    boolean existsByTransactionId(UUID transactionId);
 }

--- a/backend/src/test/java/com/smallbankapp/banking/infrastructure/messaging/kafka/KafkaMessagingIntegrationTest.java
+++ b/backend/src/test/java/com/smallbankapp/banking/infrastructure/messaging/kafka/KafkaMessagingIntegrationTest.java
@@ -1,0 +1,190 @@
+package com.smallbankapp.banking.infrastructure.messaging.kafka;
+
+import com.smallbankapp.banking.infrastructure.messaging.kafka.event.TransactionEvent;
+import com.smallbankapp.banking.infrastructure.messaging.kafka.producer.KafkaTransactionProducer;
+import com.smallbankapp.banking.infrastructure.persistence.mongo.repository.AuditLogMongoRepository;
+import com.smallbankapp.banking.infrastructure.persistence.mongo.repository.TransactionHistoryMongoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Integration test: publishes a TransactionEvent to a real Kafka (Testcontainers)
+ * and verifies both AuditLogConsumer and TransactionHistoryConsumer persist records
+ * to MongoDB within a reasonable timeout.
+ */
+@SpringBootTest
+@Testcontainers
+class KafkaMessagingIntegrationTest {
+
+    // ── Containers ────────────────────────────────────────────────────────────
+
+    @Container
+    static final PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>(DockerImageName.parse("postgres:16-alpine"))
+                    .withDatabaseName("banking")
+                    .withUsername("banking")
+                    .withPassword("banking");
+
+    @Container
+    static final MongoDBContainer mongo =
+            new MongoDBContainer(DockerImageName.parse("mongo:7"));
+
+    @Container
+    static final KafkaContainer kafka =
+            new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.1"));
+
+    // ── Dynamic Properties ───────────────────────────────────────────────────
+
+    @DynamicPropertySource
+    static void overrideProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.data.mongodb.uri", mongo::getReplicaSetUrl);
+        registry.add("spring.kafka.bootstrap-servers", kafka::getBootstrapServers);
+    }
+
+    // ── Beans ─────────────────────────────────────────────────────────────────
+
+    @Autowired
+    private KafkaTemplate<String, TransactionEvent> kafkaTemplate;
+
+    @Autowired
+    private AuditLogMongoRepository auditLogMongoRepository;
+
+    @Autowired
+    private TransactionHistoryMongoRepository transactionHistoryMongoRepository;
+
+    @BeforeEach
+    void cleanMongo() {
+        auditLogMongoRepository.deleteAll();
+        transactionHistoryMongoRepository.deleteAll();
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void depositEvent_isPersistedToAuditLog() {
+        UUID transactionId = UUID.randomUUID();
+        UUID accountId = UUID.randomUUID();
+
+        TransactionEvent event = TransactionEvent.of(
+                transactionId,
+                null,
+                accountId,
+                "DEPOSIT",
+                BigDecimal.valueOf(200.00),
+                "USD",
+                "COMPLETED",
+                Instant.now()
+        );
+
+        kafkaTemplate.send(KafkaTransactionProducer.TOPIC, accountId.toString(), event);
+
+        await().atMost(15, TimeUnit.SECONDS)
+                .untilAsserted(() ->
+                        assertThat(auditLogMongoRepository.existsByTransactionId(transactionId))
+                                .isTrue()
+                );
+    }
+
+    @Test
+    void depositEvent_isPersistedToTransactionHistory() {
+        UUID transactionId = UUID.randomUUID();
+        UUID accountId = UUID.randomUUID();
+
+        TransactionEvent event = TransactionEvent.of(
+                transactionId,
+                null,
+                accountId,
+                "DEPOSIT",
+                BigDecimal.valueOf(150.00),
+                "USD",
+                "COMPLETED",
+                Instant.now()
+        );
+
+        kafkaTemplate.send(KafkaTransactionProducer.TOPIC, accountId.toString(), event);
+
+        await().atMost(15, TimeUnit.SECONDS)
+                .untilAsserted(() ->
+                        assertThat(transactionHistoryMongoRepository.existsByTransactionId(transactionId))
+                                .isTrue()
+                );
+    }
+
+    @Test
+    void transferEvent_isPersistedWithBothAccounts() {
+        UUID transactionId = UUID.randomUUID();
+        UUID sourceId = UUID.randomUUID();
+        UUID targetId = UUID.randomUUID();
+
+        TransactionEvent event = TransactionEvent.of(
+                transactionId,
+                sourceId,
+                targetId,
+                "TRANSFER",
+                BigDecimal.valueOf(500.00),
+                "USD",
+                "COMPLETED",
+                Instant.now()
+        );
+
+        kafkaTemplate.send(KafkaTransactionProducer.TOPIC, sourceId.toString(), event);
+
+        await().atMost(15, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    assertThat(auditLogMongoRepository.existsByTransactionId(transactionId)).isTrue();
+                    assertThat(transactionHistoryMongoRepository.existsByTransactionId(transactionId)).isTrue();
+                });
+    }
+
+    @Test
+    void duplicateEvent_isNotPersistedTwice() throws InterruptedException {
+        UUID transactionId = UUID.randomUUID();
+        UUID accountId = UUID.randomUUID();
+
+        TransactionEvent event = TransactionEvent.of(
+                transactionId,
+                accountId,
+                null,
+                "WITHDRAWAL",
+                BigDecimal.valueOf(75.00),
+                "USD",
+                "COMPLETED",
+                Instant.now()
+        );
+
+        // Publish the same event twice
+        kafkaTemplate.send(KafkaTransactionProducer.TOPIC, accountId.toString(), event);
+        kafkaTemplate.send(KafkaTransactionProducer.TOPIC, accountId.toString(), event);
+
+        // Wait for consumers to process
+        TimeUnit.SECONDS.sleep(10);
+
+        // Exactly 1 audit log entry and 1 history entry must exist
+        assertThat(auditLogMongoRepository
+                .findByTransactionId(transactionId)).isPresent();
+        assertThat(transactionHistoryMongoRepository
+                .existsByTransactionId(transactionId)).isTrue();
+    }
+}


### PR DESCRIPTION
- Add TransactionEvent record
- Add KafkaTransactionProducer implementing TransactionEventPublisher port
- Add AuditLogConsumer (audit-log-group) with @RetryableTopic and idempotency
- Add TransactionHistoryConsumer (transaction-history-group) with idempotency
- Add KafkaConfig: topic beans, producer/consumer factories, DLT config
- Extend TransactionHistoryMongoRepository with existsByTransactionId
- Add KafkaMessagingIntegrationTest (4 tests, Testcontainers)
- Add awaitility 4.2.1 to pom.xml
- Update WORK_PLAN.md: Phase 5 complete
- Close GitHub issue #15