### PR TITLE
fix(jwt): add accountId claim to JWT token

### DIFF
--- a/backend/src/main/java/com/smallbankapp/banking/application/usecase/auth/query/LoginHandler.java
+++ b/backend/src/main/java/com/smallbankapp/banking/application/usecase/auth/query/LoginHandler.java
@@ -1,8 +1,10 @@
 package com.smallbankapp.banking.application.usecase.auth.query;
 
 import com.smallbankapp.banking.application.mediator.RequestHandler;
+import com.smallbankapp.banking.application.port.out.AccountRepository;
 import com.smallbankapp.banking.application.port.out.UserRepository;
 import com.smallbankapp.banking.domain.exception.InvalidCredentialsException;
+import com.smallbankapp.banking.domain.model.Account;
 import com.smallbankapp.banking.domain.model.User;
 import com.smallbankapp.banking.infrastructure.security.jwt.JwtService;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +16,7 @@ import org.springframework.stereotype.Component;
 public class LoginHandler implements RequestHandler<LoginQuery, LoginResult> {
 
     private final UserRepository userRepository;
+    private final AccountRepository accountRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtService jwtService;
 
@@ -26,7 +29,11 @@ public class LoginHandler implements RequestHandler<LoginQuery, LoginResult> {
             throw new InvalidCredentialsException();
         }
 
-        String token = jwtService.generateToken(user.getId(), user.getEmail());
+        // Resolve the account linked to this user so we can embed accountId in the JWT
+        Account account = accountRepository.findByUserId(user.getId())
+                .orElseThrow(InvalidCredentialsException::new);
+
+        String token = jwtService.generateToken(user.getId(), user.getEmail(), account.getId());
 
         return new LoginResult(token, user.getEmail(), user.getFullName());
     }

--- a/backend/src/main/java/com/smallbankapp/banking/infrastructure/security/jwt/JwtService.java
+++ b/backend/src/main/java/com/smallbankapp/banking/infrastructure/security/jwt/JwtService.java
@@ -17,10 +17,16 @@ public class JwtService {
 
     private final JwtProperties properties;
 
-    public String generateToken(UUID userId, String email) {
+    /**
+     * Generates a JWT with userId as subject plus email and accountId claims.
+     * The accountId claim allows the Angular frontend to resolve the account
+     * without an extra API call on every page load.
+     */
+    public String generateToken(UUID userId, String email, UUID accountId) {
         return Jwts.builder()
                 .subject(userId.toString())
                 .claim("email", email)
+                .claim("accountId", accountId.toString())
                 .issuedAt(new Date())
                 .expiration(new Date(System.currentTimeMillis() + properties.expirationMs()))
                 .signWith(signingKey())
@@ -33,6 +39,10 @@ public class JwtService {
 
     public String extractEmail(String token) {
         return parseClaims(token).get("email", String.class);
+    }
+
+    public String extractAccountId(String token) {
+        return parseClaims(token).get("accountId", String.class);
     }
 
     public boolean isTokenValid(String token) {

--- a/backend/src/test/java/com/smallbankapp/banking/application/usecase/auth/query/LoginHandlerTest.java
+++ b/backend/src/test/java/com/smallbankapp/banking/application/usecase/auth/query/LoginHandlerTest.java
@@ -1,8 +1,14 @@
 package com.smallbankapp.banking.application.usecase.auth.query;
 
+import com.smallbankapp.banking.application.port.out.AccountRepository;
 import com.smallbankapp.banking.application.port.out.UserRepository;
 import com.smallbankapp.banking.domain.exception.InvalidCredentialsException;
+import com.smallbankapp.banking.domain.model.Account;
 import com.smallbankapp.banking.domain.model.User;
+import com.smallbankapp.banking.domain.valueobject.AccountNumber;
+import com.smallbankapp.banking.domain.valueobject.AccountStatus;
+import com.smallbankapp.banking.domain.valueobject.AccountType;
+import com.smallbankapp.banking.domain.valueobject.Money;
 import com.smallbankapp.banking.infrastructure.security.jwt.JwtService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,12 +29,14 @@ import static org.mockito.Mockito.*;
 class LoginHandlerTest {
 
     @Mock UserRepository userRepository;
+    @Mock AccountRepository accountRepository;
     @Mock PasswordEncoder passwordEncoder;
     @Mock JwtService jwtService;
 
     @InjectMocks LoginHandler handler;
 
     private User mockUser;
+    private Account mockAccount;
     private LoginQuery query;
 
     @BeforeEach
@@ -41,6 +49,16 @@ class LoginHandlerTest {
                 Instant.now(),
                 Instant.now()
         );
+        mockAccount = new Account(
+                UUID.randomUUID(),
+                mockUser.getId(),
+                AccountNumber.of("1234567890"),
+                AccountType.SAVINGS,
+                Money.of(0.0, "USD"),
+                AccountStatus.ACTIVE,
+                Instant.now(),
+                Instant.now()
+        );
         query = new LoginQuery("test@email.com", "Password1!");
     }
 
@@ -48,7 +66,9 @@ class LoginHandlerTest {
     void handle_validCredentials_returnsTokenAndUserInfo() {
         when(userRepository.findByEmail(query.email())).thenReturn(Optional.of(mockUser));
         when(passwordEncoder.matches(query.password(), mockUser.getPasswordHash())).thenReturn(true);
-        when(jwtService.generateToken(mockUser.getId(), mockUser.getEmail())).thenReturn("jwt-token");
+        when(accountRepository.findByUserId(mockUser.getId())).thenReturn(Optional.of(mockAccount));
+        when(jwtService.generateToken(mockUser.getId(), mockUser.getEmail(), mockAccount.getId()))
+                .thenReturn("jwt-token");
 
         LoginResult result = handler.handle(query);
 
@@ -64,7 +84,7 @@ class LoginHandlerTest {
         assertThatThrownBy(() -> handler.handle(query))
                 .isInstanceOf(InvalidCredentialsException.class);
 
-        verify(jwtService, never()).generateToken(any(), any());
+        verify(jwtService, never()).generateToken(any(), any(), any());
     }
 
     @Test
@@ -75,6 +95,18 @@ class LoginHandlerTest {
         assertThatThrownBy(() -> handler.handle(query))
                 .isInstanceOf(InvalidCredentialsException.class);
 
-        verify(jwtService, never()).generateToken(any(), any());
+        verify(jwtService, never()).generateToken(any(), any(), any());
+    }
+
+    @Test
+    void handle_accountNotFound_throwsInvalidCredentialsException() {
+        when(userRepository.findByEmail(query.email())).thenReturn(Optional.of(mockUser));
+        when(passwordEncoder.matches(query.password(), mockUser.getPasswordHash())).thenReturn(true);
+        when(accountRepository.findByUserId(mockUser.getId())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> handler.handle(query))
+                .isInstanceOf(InvalidCredentialsException.class);
+
+        verify(jwtService, never()).generateToken(any(), any(), any());
     }
 }


### PR DESCRIPTION
- JwtService.generateToken now accepts accountId and emits it as claim
- LoginHandler resolves account via AccountRepository before generating token
- LoginHandlerTest updated: 3-arg generateToken mock + accountNotFound test
- BUG_KB.md: BUG-001 documented

Required for Angular frontend Dashboard and History pages to function without an extra API call on page load.